### PR TITLE
Print Timestamp in link crc mocker

### DIFF
--- a/lom/src/plugins/plugins_files/sonic/plugin_integration_tests/linkcrc_mocker/linkcrc_utils/linkcrc_utils.go
+++ b/lom/src/plugins/plugins_files/sonic/plugin_integration_tests/linkcrc_mocker/linkcrc_utils/linkcrc_utils.go
@@ -6,6 +6,8 @@ import (
     "lom/src/plugins/plugins_files/sonic/plugin_integration_tests/utils"
     "strings"
     "time"
+    "fmt"
+    "errors"
 )
 
 const (
@@ -24,6 +26,11 @@ const (
     ifUp                             = "up"
     counters_db                      = "COUNTERS:"
 )
+
+type InterfaceStatus struct {
+	admin_status string
+	oper_status  string
+}
 
 func MockRedisWithLinkCrcCounters(pattern string, mockTimeInMinutes int, interfaces []string, ctx context.Context) {
     var countersDbClient = redis.NewClient(&redis.Options{
@@ -51,6 +58,14 @@ func MockRedisWithLinkCrcCounters(pattern string, mockTimeInMinutes int, interfa
         Password: redis_password,
         DB:       redis_app_db,
     })
+
+    initialInterfaceStatuses, err := SaveInterfaceStatuses(appDbClient, mockedLinks)
+    defer RestoreInterfaceStatuses(appDbClient, initialInterfaceStatuses)
+    if err != nil {
+        utils.PrintError("Could not save the initial interface statuses locally.")
+        return
+    }
+
     ifStatusMock := map[string]interface{}{admin_status: ifUp, oper_status: ifUp}
     for k, _ := range mockedLinks {
         _, err = appDbClient.HMSet("PORT_TABLE:"+k, ifStatusMock).Result()
@@ -89,8 +104,12 @@ loop:
                 utils.PrintError("Error mocking redis data for interface %s. Err %v", ifName, err)
                 return
             } else {
-                utils.PrintInfo("Successfuly mocked redis data for interface %s", ifName)
-            }
+                if patternIndex == 0 {
+                    utils.PrintInfo("Initial mocking of redis data for interface Succeeded. %s", ifName)
+                } else {
+                    utils.PrintInfo("Successfuly mocked redis data for interface %s. TimeInUtc: %s. Outlier: %t", ifName, time.Now().UTC().String(), patternSlice[(patternIndex-1)%patternLength] == "1")
+                } 
+	    }
         }
 
         if patternSlice[(patternIndex)%patternLength] == "1" {
@@ -116,4 +135,46 @@ loop:
         }
     }
     utils.PrintInfo("Done mocking redis")
+}
+
+func SaveInterfaceStatuses(redisClient *redis.Client, mockedLinks map[string]string) (map[string]*InterfaceStatus, error) {
+	initialInterfaceStatuses := make(map[string]*InterfaceStatus)
+	for ifName, _ := range mockedLinks {
+		adminStatus, operStatus, err := getInterfaceStatus(redisClient, ifName)
+
+		if err != nil {
+			/* Send partial result */
+			return initialInterfaceStatuses, err
+		}
+
+		intStatus := InterfaceStatus{admin_status: adminStatus, oper_status: operStatus}
+		initialInterfaceStatuses[ifName] = &intStatus
+	}
+
+	return initialInterfaceStatuses, nil
+}
+
+func RestoreInterfaceStatuses(redisClient *redis.Client, initialStatuses map[string]*InterfaceStatus) error {
+	for ifName, intStatus := range initialStatuses {
+		ifStatusMock := map[string]interface{}{admin_status: intStatus.admin_status, oper_status: intStatus.oper_status}
+		_, err := redisClient.HMSet("PORT_TABLE:"+ifName, ifStatusMock).Result()
+		if err != nil {
+			utils.PrintError("Error restoring admin and oper status for interface %s. Err: %v", ifName, err)
+		} else {
+			utils.PrintInfo("Successfully restored admin and oper status for interface %s", ifName)
+		}
+	}
+
+	utils.PrintInfo("Done restoring statuses of all interfaces.")
+	return nil
+}
+
+func getInterfaceStatus(redisClient *redis.Client, interfaName string) (string, string, error) {
+	interfaceStatusKey := "PORT_TABLE:" + interfaName
+	fields := []string{"admin_status", "oper_status"}
+	result, err := redisClient.HMGet(interfaceStatusKey, fields...).Result()
+	if err != nil {
+		return "", "", errors.New(fmt.Sprintf("getInterfaceStatus.HmGet Failed for key (%s). err: (%v)", interfaceStatusKey, err))
+	}
+	return result[0].(string), result[1].(string), nil
 }

--- a/lom/src/plugins/plugins_files/sonic/plugin_integration_tests/linkcrc_mocker/main.go
+++ b/lom/src/plugins/plugins_files/sonic/plugin_integration_tests/linkcrc_mocker/main.go
@@ -10,6 +10,7 @@ import (
 
 const (
     counter_poll_disable_command = "sudo counterpoll port disable"
+    counter_poll_enable_command  = "sudo counterpoll port enable"
 )
 
 func main() {
@@ -43,4 +44,11 @@ func main() {
         utils.PrintError("Invalid test Id %d", testId)
     }
 
+    // Post - clean up
+    _, err = exec.Command("/bin/sh", "-c", counter_poll_enable_command).Output()
+    if err != nil {
+        utils.PrintError("Error enabling counterpoll on switch %v", err)
+    } else {
+        utils.PrintInfo("Successfuly Enabled counterpoll")
+    }
 }


### PR DESCRIPTION
- Prints timestamp while mocking redis 
- Indicates if a mock was an outlier or not in the logs.
- Restores original state of links after mocking.