### PR TITLE
Add detailed version info to LoM 

### DIFF
--- a/LoM-Install/decompress.j2
+++ b/LoM-Install/decompress.j2
@@ -19,7 +19,7 @@ function usage()
 function testArgs()
 {
     if  [[ $# == 1 && "$1" == "-v" ]]; then
-        echo ${LOM_VERSION_JSON} | jq
+        echo ${LOM_VERSION_JSON} | jq -r | jq
         echo "HostVersion = ${HOST_OS_VERSION}"
         exit 0
     fi

--- a/LoM-Install/decompress.j2
+++ b/LoM-Install/decompress.j2
@@ -9,9 +9,10 @@ HOST_OS_VERSION={{ HOST_OS_VERSION }}
 function usage()
 {
     echo -e "\
+        -c - Clean all the backup \n\
         -i - Does install or upgrade \n\
         -r - Force a rollback \n\
-        -c - Clean all the backup \n\
+        -v - Dump LoM vresion info\n\
         -h - Usage"
     exit -1
 }

--- a/LoM-Install/decompress.j2
+++ b/LoM-Install/decompress.j2
@@ -14,7 +14,9 @@ function testArgs()
 {
     VERSION={{ LoMVersion }}
     if  [[ $# == 1 && "$1" == "-v" ]]; then
-        echo ${VERSION}
+        echo "LoMVersion = ${{ LoMVersion }}"
+        echo "LoMBranch = ${{ LoMBranch }}"
+        echo "LoMCommit = ${{ LoMCommit }}"
         exit 0
     fi
 

--- a/LoM-Install/decompress.j2
+++ b/LoM-Install/decompress.j2
@@ -1,5 +1,11 @@
 #! /bin/bash
 
+# The variables below are populated at build time via J2 variable.
+# This helps see version info of the blob w/o installing/extracting.
+#
+LOM_VERSION_JSON={{ LOM_VERSION_JSON }}
+HOST_OS_VERSION={{ HOST_OS_VERSION }}
+
 function usage()
 {
     echo -e "\
@@ -12,11 +18,9 @@ function usage()
 
 function testArgs()
 {
-    VERSION={{ LoMVersion }}
     if  [[ $# == 1 && "$1" == "-v" ]]; then
-        echo "LoMVersion = ${{ LoMVersion }}"
-        echo "LoMBranch = ${{ LoMBranch }}"
-        echo "LoMCommit = ${{ LoMCommit }}"
+        echo ${LOM_VERSION_JSON} | jq
+        echo "HostVersion = ${HOST_OS_VERSION}"
         exit 0
     fi
 

--- a/LoM-Install/sonic/LoM-install.sh
+++ b/LoM-Install/sonic/LoM-install.sh
@@ -129,16 +129,10 @@ function testInstall()
     #
     fStart testInstall
 
-    # Match the build from LoM's version with switch's version
-    # Take first component from install/VERSION string
-    # Take second component from /etc/sonic/sonic_version.yml's build_version's value
+    # TODO - Validate current Host OS Version with build_version from install/sonic_version.yml
+    # May have to revise the plan of matching
+    # May have to add target versions vetted in nightly tests.
     #
-    # TODO: This breaks for private builds. Need to mature before bringing this constraint.
-    #
-    # OS_Version=$(cat /etc/sonic/sonic_version.yml | grep -e "^build_version" | cut -f2 -d\'| cut -f1 -d .)
-    # LoM_Version="$(cat $(dirname $0)/VERSION |  tr -d '\n' | cut -f1 -d .)"
-    # [[ ${OS_Version} != ${LoM_Version} ]] && fail "Version mismatch. OS=${OS_Version} LoM=${LoM_Version}" ${ERR_TEST}
-
     # Get image info & validate too.
     getTag
 
@@ -302,7 +296,7 @@ function installCode()
     fl="$(dirname $0)/../install/${IMAGE_FILE}"
     docker load -i ${fl}
     [[ $? != 0 ]] && { fail "Failed to load docker image ${fl}" ${ERR_INSTALL_CODE}; }
-    tag="$(cat $(dirname $0)/VERSION |  tr -d '\n')"
+    tag="$(cat $(dirname $0)/sonic_version.yml | grep -e "^build_version" |  cut -f2 -d\')"
     docker tag ${IMAGE_NAME}:latest ${IMAGE_NAME}:${tag}
     [[ $? != 0 ]] && { fail "Failed to tag ${IMAGE_NAME}:latest to ${tag}" ${ERR_INSTALL_CODE}; }
 
@@ -404,6 +398,10 @@ function testSudo()
     fi
 }
 
+function cpSONiCVer()
+{
+    docker cp $(dirname $0)/sonic_version.yml device-health:/usr/share/lom/
+}
 
 function main()
 {
@@ -460,6 +458,9 @@ function main()
     testInstall
     if [[ ${image_latest} == 1 ]]; then
         serviceRestart
+    fi
+    if [[ ${OP_INSTALL} == 1 ]]; then
+        cpSONiCVer
     fi
     echo "\"$0 $@\" - Ran successfully"
     exit 0

--- a/LoM-Install/sonic/common.sh
+++ b/LoM-Install/sonic/common.sh
@@ -26,6 +26,8 @@ IMAGE_NAME="docker-device-health"
 IMAGE_FILE="${IMAGE_NAME}.gz"
 INSTALL_SCRIPT="LoM-install.sh"
 COMMON_SCRIPT="common.sh"
+LOM_VERSION_FILE="LoM-Version.json"
+HOST_VERSION_FILE="sonic_version.yml"
 
 BACK_EXT="bak"
 

--- a/LoM-Install/sonic/make-install-archive.sh
+++ b/LoM-Install/sonic/make-install-archive.sh
@@ -19,7 +19,9 @@ INTEGRATION_TEST_DST="${PAYLOAD_DIR}/${TEST_SUBDIR}/${INTEGRATION_TEST_BIN}"
 
 INSTALL_FILES="target/${IMAGE_FILE} \
     ${INSTALL_SRC_DIR}/${INSTALL_SCRIPT} \
-    ${INSTALL_SRC_DIR}/${COMMON_SCRIPT}"
+    ${INSTALL_SRC_DIR}/${COMMON_SCRIPT} \
+    ${LOM_SRC_DIR}/config/${LOM_VERSION_FILE} \
+    ./fsroot-broadcom/etc/sonic/${HOST_VERSION_FILE}"
 
 # Validate ...
 [[ ! -d "./target" ]] && { echo "Run from buildimage root"; exit ${ERR_USAGE}; }
@@ -73,7 +75,9 @@ tar -cvzf ${WORK_DIR}/${INSTALLER_ARCHIVE} .
 [[ $? != 0 ]] && { echo "Failed to archive"; exit ${ERR_TAR}; }
 popd
 
-j2 -o ${WORK_DIR}/decompress -f json ${INSTALL_SRC_DIR}/../decompress.j2 ${LOM_SRC_DIR}/config/LoM-Version.json
+LOM_VERSION_JSON=$(cat ${LOM_SRC_DIR}/config/${LOM_VERSION_FILE}) \
+    HOST_OS_VERSION=$(grep build_version ${HOST_DIR}/sonic_version.yml | cut -f2 -d\') \
+    j2 -o ${WORK_DIR}/decompress${INSTALL_SRC_DIR}/../decompress.j2
 
 pushd ${WORK_DIR}
 cat decompress ${INSTALLER_ARCHIVE} > ${INSTALLER_SELF_EXTRACT}

--- a/LoM-Install/sonic/make-install-archive.sh
+++ b/LoM-Install/sonic/make-install-archive.sh
@@ -33,13 +33,6 @@ do
     [[ ! -f $i ]] && { echo "Missing file $i"; exit ${ERR_USAGE}; }
 done
 
-
-SONIC_VER_FILE="fsroot-broadcom/etc/sonic/sonic_version.yml"
-[[ ! -f ${SONIC_VER_FILE} ]] && { echo "Missing file ${SONIC_VER_FILE}"; exit ${ERR_USAGE}; }
-
-BUILD_VER=$(cat ${SONIC_VER_FILE} | grep -e "^build_version" | cut -f2 -d\'| cut -f1 -d .)
-[[ "${BUILD_VER}" == "" ]] && { echo "Failed to get build version"; exit ${ERR_USAGE}; }
-
 while getopts "t" opt; do
   case ${opt} in
     t )
@@ -74,8 +67,6 @@ if [[ "${INCLUDE_TEST_ARCHIVE}" != "" ]]; then
 else
     echo "Skip to copy integration-test code: ${INTEGRATION_TEST_BIN}"
 fi
-
-BUILDVER=${BUILD_VER} TIMESTAMP="$(date +%s)" j2 -o ${INSTALL_DIR}/VERSION -f env src/sonic-device-health/LoM_Version.j2
 
 pushd ${PAYLOAD_DIR}
 tar -cvzf ${WORK_DIR}/${INSTALLER_ARCHIVE} .

--- a/LoM-Install/sonic/make-install-archive.sh
+++ b/LoM-Install/sonic/make-install-archive.sh
@@ -75,9 +75,9 @@ tar -cvzf ${WORK_DIR}/${INSTALLER_ARCHIVE} .
 [[ $? != 0 ]] && { echo "Failed to archive"; exit ${ERR_TAR}; }
 popd
 
-LOM_VERSION_JSON=$(cat ${LOM_SRC_DIR}/config/${LOM_VERSION_FILE}) \
-    HOST_OS_VERSION=$(grep build_version ${HOST_DIR}/sonic_version.yml | cut -f2 -d\') \
-    j2 -o ${WORK_DIR}/decompress${INSTALL_SRC_DIR}/../decompress.j2
+LOM_VERSION_JSON=$(cat ${LOM_SRC_DIR}/config/${LOM_VERSION_FILE} | jq -c | jq -R) \
+    HOST_OS_VERSION=$(grep build_version ${INSTALL_DIR}/sonic_version.yml | cut -f2 -d\') \
+    j2 -o ${WORK_DIR}/decompress ${INSTALL_SRC_DIR}/../decompress.j2
 
 pushd ${WORK_DIR}
 cat decompress ${INSTALLER_ARCHIVE} > ${INSTALLER_SELF_EXTRACT}

--- a/LoM-Install/sonic/make-install-archive.sh
+++ b/LoM-Install/sonic/make-install-archive.sh
@@ -1,5 +1,11 @@
 #! /bin/bash
 
+# TODO: 
+#   Update usr/bin/device-health.sh to mount dirs as desired by plugins
+#   Dirs of interest are to be registered in one file by each plugin
+#   At build time, it ensures usr/bin/device-health.sh is created such that
+#   all these dirs are mounted. May be as RO only.
+#
 source $(dirname $0)/common.sh
 
 INSTALL_SRC_DIR="$(dirname $0)"

--- a/LoM_Version.j2
+++ b/LoM_Version.j2
@@ -1,1 +1,0 @@
-{{ BUILDVER }}.0.0.{{ TIMESTAMP }}

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,15 @@ CP := cp
 RM := rm
 
 ifeq ($(SONIC_IMAGE_VERSION),)
-	override SONIC_IMAGE_VERSION := "0.0.0"
+VENDOR = sonic
+endif
+
+ifeq ($(VENDOR),)
+$(error Specify vendor as sonic/arista/cisco!)
+endif
+
+ifeq ("$(wildcard $(CONFIG_DIR)/$(VENDOR)/VersionInfo)","")
+$(error Expect $(CONFIG_DIR)/$(VENDOR)/VersionInfo to exist!)
 endif
 
 all: go-all $(VERSION_CONFIG)
@@ -34,7 +42,7 @@ go-all:
 # Generate conf files
 $(VERSION_CONFIG): $(CONFIG_DIR)/LoM-Version.json.j2
 	@echo "+++ --- Creating Version JSON $(HOST_OS_VERSION)--- +++"
-	$(shell HOST_OS_VERSION=$(SONIC_IMAGE_VERSION) HOST_VENDOR=SONiC j2 -o $(VERSION_CONFIG) $(CONFIG_DIR)/LoM-Version.json.j2)
+	$(shell . $(CONFIG_DIR)/$(VENDOR)/VersionInfo && j2 -o $(VERSION_CONFIG) $(CONFIG_DIR)/LoM-Version.json.j2)
 	@echo "+++ --- Creating Version JSON DONE --- +++"
 
 

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ MKDIR := mkdir
 CP := cp
 RM := rm
 
-ifdef SONIC_IMAGE_VERSION
+ifdef SONIC_OS_VERSION
 VENDOR = sonic
 endif
 
@@ -31,7 +31,7 @@ VERSION_TEMPLATE_FILE = $(CONFIG_DIR)/LoM-Version.json.j2
 
 
 ifeq ("$(wildcard $(VERSION_SRC_FILE))","")
-$(error Expect $(VERSION_SRC_FILE) to exist. Refer VersionSrc.sample for deails!)
+$(error Expect $(VERSION_SRC_FILE) to exist. Refer VersionSrc.sample for details!)
 endif
 
 all: go-all $(VERSION_CONFIG)
@@ -47,9 +47,6 @@ go-all:
 $(VERSION_CONFIG): $(CONFIG_DIR)/LoM-Version.json.j2 
 	@echo "+++ --- Creating Version JSON $(HOST_OS_VERSION)--- +++"
 	$(VERSION_SRC_FILE) $(VERSION_TEMPLATE_FILE) $(VERSION_CONFIG)
-	ifeq ("$(wildcard $(VERSION_CONFIG))","")
-		$(error Expect $(VERSION_CONFIG) to exist. Refer VersionSrc.sample for deails!)
-	endif
 	@echo "+++ --- Creating Version JSON DONE --- +++"
 
 

--- a/config/LoM-Version.json.j2
+++ b/config/LoM-Version.json.j2
@@ -1,8 +1,8 @@
 {
-    "HostVersion": "{{ HOST_OS_VERSION }}",
     "LoMVersion": "0.0.0",
-    "vendor": "{{ HOST_VENDOR }}",
-    "LoMBranch": {{ LOM_BRANCH }}",
-    "LoMCommit": {{ LOM_COMMIT }}",
+    "Hostvendor": "{{ HOST_VENDOR }}",
+    "LoMRepo": "{{ LOM_REPO }}",
+    "LoMBranch": "{{ LOM_BRANCH }}",
+    "LoMCommit": "{{ LOM_COMMIT }}",
     "description": "Initial"
 }

--- a/config/LoM-Version.json.j2
+++ b/config/LoM-Version.json.j2
@@ -2,5 +2,7 @@
     "HostVersion": "{{ HOST_OS_VERSION }}",
     "LoMVersion": "0.0.0",
     "vendor": "{{ HOST_VENDOR }}",
+    "LoMBranch": {{ LOM_BRANCH }}",
+    "LoMCommit": {{ LOM_COMMIT }}",
     "description": "Initial"
 }

--- a/config/LoM-Version.json.j2
+++ b/config/LoM-Version.json.j2
@@ -1,6 +1,8 @@
 {
     "LoMVersion": "0.0.0",
     "Hostvendor": "{{ HOST_VENDOR }}",
+    "HostRepo": "{{ HOST_REPO }}",
+    "HostCommit": "{{ HOST_COMMIT }}",
     "LoMRepo": "{{ LOM_REPO }}",
     "LoMBranch": "{{ LOM_BRANCH }}",
     "LoMCommit": "{{ LOM_COMMIT }}",

--- a/config/sonic/VersionSrc.sample
+++ b/config/sonic/VersionSrc.sample
@@ -23,7 +23,7 @@ popd
 LOM_BRANCH=verUpd \
 LOM_COMMIT=$(git log --pretty=format:'%h' -n 1) \
 LOM_REPO=$(git remote -v | head -n 1 | sed 's/\t/ /g' | tr -s ' ' | cut -f2 -d' ') \
-HOST_VENDOR=sonic HOST_REPO=${HRepo" HOST_COMMIT=${HCmt} \
+HOST_VENDOR=sonic HOST_REPO=${HRepo} HOST_COMMIT=${HCmt} \
 j2 -o $2 $1
 
 exit $?

--- a/config/sonic/VersionSrc.sample
+++ b/config/sonic/VersionSrc.sample
@@ -21,7 +21,7 @@ HCmt=$(git log --pretty=format:'%h' -n 1)
 popd
 
 # Add this LOM_BRANCH for this command to succeed.
-# LOM_BRANCH=Unknown \      
+# LOM_BRANCH=Unknown \
 LOM_COMMIT=$(git log --pretty=format:'%h' -n 1) \
 LOM_REPO=$(git remote -v | head -n 1 | sed 's/\t/ /g' | tr -s ' ' | cut -f2 -d' ') \
 HOST_VENDOR=sonic HOST_REPO=${HRepo} HOST_COMMIT=${HCmt} \

--- a/config/sonic/VersionSrc.sample
+++ b/config/sonic/VersionSrc.sample
@@ -1,5 +1,11 @@
 # Create this file in submod with appropriate info
 # This is used in LoM-Version file.
+# Note: source branch info will not be available in submod.
+#       We just do "git reset --hard origin/<some branch>.
+#       This info is not retrievable.
+#       Hence manual update is needed.
+#       Which is why we don't checkin VersionSrc file and force dev to create one.
+#
 LOM_BRANCH=xxx
-LOM_COMMIT=yyy
+LOM_COMMIT=$(git log --pretty=format:'%h' -n 1)
 HOST_VENDOR="sonic"

--- a/config/sonic/VersionSrc.sample
+++ b/config/sonic/VersionSrc.sample
@@ -1,0 +1,5 @@
+# Create this file in submod with appropriate info
+# This is used in LoM-Version file.
+LOM_BRANCH=xxx
+LOM_COMMIT=yyy
+HOST_VENDOR="sonic"

--- a/config/sonic/VersionSrc.sample
+++ b/config/sonic/VersionSrc.sample
@@ -20,7 +20,8 @@ HRepo=$(git remote -v | head -n 1 | sed 's/\t/ /g' | tr -s ' ' | cut -f2 -d' ')
 HCmt=$(git log --pretty=format:'%h' -n 1)
 popd
 
-LOM_BRANCH=verUpd \
+# Add this LOM_BRANCH for this command to succeed.
+# LOM_BRANCH=Unknown \      
 LOM_COMMIT=$(git log --pretty=format:'%h' -n 1) \
 LOM_REPO=$(git remote -v | head -n 1 | sed 's/\t/ /g' | tr -s ' ' | cut -f2 -d' ') \
 HOST_VENDOR=sonic HOST_REPO=${HRepo} HOST_COMMIT=${HCmt} \

--- a/config/sonic/VersionSrc.sample
+++ b/config/sonic/VersionSrc.sample
@@ -15,11 +15,15 @@ if [ $# -ne 2 ]; then
     echo "Expect $0 <template> <o/p file>"
     exit -1
 fi
+pushd $(dirname $0)/../../..
+HRepo=$(git remote -v | head -n 1 | sed 's/\t/ /g' | tr -s ' ' | cut -f2 -d' ')
+HCmt=$(git log --pretty=format:'%h' -n 1)
+popd
 
 LOM_BRANCH=verUpd \
 LOM_COMMIT=$(git log --pretty=format:'%h' -n 1) \
 LOM_REPO=$(git remote -v | head -n 1 | sed 's/\t/ /g' | tr -s ' ' | cut -f2 -d' ') \
-HOST_VENDOR=sonic \
+HOST_VENDOR=sonic HOST_REPO=${HRepo" HOST_COMMIT=${HCmt} \
 j2 -o $2 $1
 
 exit $?

--- a/config/sonic/VersionSrc.sample
+++ b/config/sonic/VersionSrc.sample
@@ -1,3 +1,7 @@
+#! /bin/bash
+
+set -x 
+
 # Create this file in submod with appropriate info
 # This is used in LoM-Version file.
 # Note: source branch info will not be available in submod.
@@ -5,7 +9,17 @@
 #       This info is not retrievable.
 #       Hence manual update is needed.
 #       Which is why we don't checkin VersionSrc file and force dev to create one.
+# TODO - Get it from SONIC image version
 #
-LOM_BRANCH=xxx
-LOM_COMMIT=$(git log --pretty=format:'%h' -n 1)
-HOST_VENDOR="sonic"
+if [ $# -ne 2 ]; then
+    echo "Expect $0 <template> <o/p file>"
+    exit -1
+fi
+
+LOM_BRANCH=verUpd \
+LOM_COMMIT=$(git log --pretty=format:'%h' -n 1) \
+LOM_REPO=$(git remote -v | head -n 1 | sed 's/\t/ /g' | tr -s ' ' | cut -f2 -d' ') \
+HOST_VENDOR=sonic \
+j2 -o $2 $1
+
+exit $?


### PR DESCRIPTION
Add Lom Version & OS version info into container.
This is *required* when we multiple devs build and we do incremental changes & rebuild. 
W/o this info, it would be hard for us to track the source commit to the binaries.

admin@str-s6000-acs-11:~$ sudo bash ./LoM-Install.bsx -v
{
  "LoMVersion": "0.0.0",
  "Hostvendor": "sonic",
  "HostRepo": "https://github.com/renukamanavalan/sonic-buildimage.git",
  "HostCommit": "7a13423b2",
  "LoMRepo": "https://github.com/renukamanavalan/sonic-device-health.git",
  "LoMBranch": "verUpd",
  "LoMCommit": "ce8ed44",
  "description": "Initial"
}
HostVersion = 20220511.0-7bf37d97c

root@str-s6000-acs-11:/# ls -l /usr/share/lom/
total 44
-rw-r--r-- 1 root root   325 Feb 19 00:47 LoM-Version.json
-rwxr-xr-x 1 root root 12315 Feb 19 00:47 LoM-install.sh
-rw-r--r-- 1 root root   426 Feb 19 00:47 actions.conf.json
-rw-r--r-- 1 root root   221 Feb 19 00:47 bindings.conf.json
-rwxr-xr-x 1 root root   816 Feb 19 00:47 common.sh
-rw-r--r-- 1 root root   416 Feb 19 00:47 globals.conf.json
-rw-r--r-- 1 root root   123 Feb 19 00:47 procs.conf.json
-rw-r--r-- 1 1000 1000   361 Feb 19 18:51 sonic_version.yml
root@str-s6000-acs-11:/# 

remanava@remanava-dev-vm:~/sonic/fork/202205-sonic-buildimage$ ./target/LoM-Install.bsx -h
        -c - Clean all the backup 
        -i - Does install or upgrade 
        -r - Force a rollback 
        -v - Dump LoM vresion info
        -h - Usage